### PR TITLE
Add gen-packages and package-dir configurations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,20 @@ Apart from passing options on the command line it's also possible to add a dedic
     # Dump lots of logging info to antlr-<timestamp>.log (yes|no); default: no
     #x-log = no
 
+Some flags specific to setuptools-antlr can also be provided to the ``[antlr]``
+section of your ``setup.cfg``.
+
+.. code:: ini
+
+    [antlr]
+    # Configure the root directory for your module; default: .
+    #package-dir = .
+
+    # Control the creation of __init__.py files in all directories about output
+    # directories; default: yes
+    #gen-packages = yes
+
+
 A reference configuration is provided in the ``resources`` directory.
 
 Sample

--- a/resources/setup.cfg
+++ b/resources/setup.cfg
@@ -37,3 +37,10 @@
 #x-force-atn = no
 # Dump lots of logging info to antlr-<timestamp>.log (yes|no); default: no
 #x-log = no
+
+# Configure the root directory for your module; default: .
+#package-dir = .
+
+# Control the creation of __init__.py files in all directories about output
+# directories; default: yes
+#gen-packages = yes


### PR DESCRIPTION
The 'gen-packages' configuration is a boolean config that controls the command's recursive scan of grammar-package directories. When set to false ("no"), the tool won't add __init__.py files to any directories other than the grammar parsers' directory.

The 'package-dir' flag tells control what is considered the "base_dir" for the creation of __init__.py files. The base_dir is excluded from the creation of __init__.py files.